### PR TITLE
Support setting the write concern option in config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Inside of your StatsD server config file, use the following parameters:
 	mongoMax: 2160, 
 	mongoPrefix: true, 
 	mongoName: 'databaseName',
+	mongoW: 0,
 	backends: ['/path/to/module/lib/index.js']
 }
 
@@ -29,6 +30,7 @@ Inside of your StatsD server config file, use the following parameters:
 * `mongoHost`: the ip address or hostname of the mongo server. Default is `localhost`.
 * `mongoMax`: the number of data points to cap the collection with. Default is `2160`. With Statsd's default of 10 seconds, this gives 6 hours of 'near real-time' data.
 * `mongoPrefix`: Boolean. If true, then the statsd "bucket" names contain a prefix which deterine the database name. For example, if a counter is called 'web-server.page_hits' then the database name will be 'web-server' and the collection name will be 'page_hits'. Otherwise, the database name will be 'statsd' and the collection name will be 'web-server.page_hits'.
+* `mongoW`: integer. The MongoDB `w` write concern parameter. Values below 1 mean unconfirmed writes.
 
 ## Schema
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,19 +11,20 @@ var mongo = require('mongodb'),
 		max: 2610,
 		name: 'statsd',
 		host: '127.0.0.1',
-		port: 27017
+		port: 27017,
+		w: 0
 	};
 
 var connection_queue = async.queue(function(task, callback) {
 	if(dbs[task.name]) {
 		callback(null, dbs[task.name]);
 	} else {
-		new mongo.Db(task.name, new mongo.Server(options.host, options.port)).open(function(err, db) {
+		new mongo.Db(task.name, new mongo.Server(options.host, options.port), options).open(function(err, db) {
 			if (err) {
 				callback(err);
 			} else {
 				dbs[task.name] = db;
-				callback(null, db);	
+				callback(null, db);
 			}
 		});
 	}
@@ -31,7 +32,7 @@ var connection_queue = async.queue(function(task, callback) {
 
 var database = function(name, callback) {
 	if(dbs[name]) {
-		callback(null, dbs[name]);	
+		callback(null, dbs[name]);
 	} else {
 		connection_queue.push({name: name}, function(err) {
 			callback(err, dbs[name]);
@@ -47,11 +48,11 @@ var dbPrefix = function(metric) {
 };
 
 /**
- *	Prefix a collection name	
+ *	Prefix a collection name
  */
 var colPrefix = function(metric_type, metric) {
 	var ary = metric.split('.');
-	if (options.prefix) ary.shift();
+	if (options.prefix){ary.shift();}
 	ary.unshift(metric_type);
 	return ary.join('.')+'_'+options.rate;
 };
@@ -157,10 +158,10 @@ var insert = function(dbName, collection, metric, callback) {
 			return callback(err);
 		};
 
-		db.createCollection(collection, colInfo, function(err, collClient) {      
+		db.createCollection(collection, colInfo, function(err, collClient) {
 			collClient.insert(metric, function(err, data){
-				if (err) callback(err);
-				if (!err) callback(false, collection);
+				if (err){callback(err);}
+				if (!err){callback(false, collection);}
 			});
 		});
 	});
@@ -179,7 +180,7 @@ var onFlush = function(time, metrics) {
 			obj = aggregate[type](time, key, metrics[type][key]);
 
 			insert(obj.db, obj.col, obj.data, function(err){
-				if (err) console.log(err);
+				if (err){console.log(err);}
 			});
 		};
 	});
@@ -192,7 +193,9 @@ var onFlush = function(time, metrics) {
  *	@param {Object} events
  */
 exports.init = function(startup_time, config, events) {
-	if (!startup_time || !config || !events) return false;
+	if (!startup_time || !config || !events) {
+    return false;
+  }
 
 	options.debug = config.debug;
 
@@ -207,6 +210,7 @@ exports.init = function(startup_time, config, events) {
 	options.prefix = typeof config.mongoPrefix == 'boolean' ? config.mongoPrefix : true;
 	options.name = config.mongoName;
 	options.port = config.mongoPort || options.port;
+  options.w = config.mongoW || options.w;
 
 	events.on('flush', onFlush);
 


### PR DESCRIPTION
With recent MongoDB versions (currently 2.4.5), establishing the connection without setting a write concern causes warnings to be emitted. This PR suggests a way to set the parameter in config.
- define it in the README
- pass the options to the Db constructor
