### PR TITLE
Fixing error when connection does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This backend uses Mongo's capped collections to have near file system performanc
 
 ## Installation
 
-As there are some minor changes from NPM, you will need to [Install Manually](http://stackoverflow.com/questions/5786433/how-to-install-a-node-js-module-without-using-npm)
+As there are some minor changes from NPN, you will need to [Install Manually](http://stackoverflow.com/questions/5786433/how-to-install-a-node-js-module-without-using-npm)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This backend uses Mongo's capped collections to have near file system performanc
 
 ## Installation
 
-As there are some minor changes from NPN, you will need to [Install Manually](http://stackoverflow.com/questions/5786433/how-to-install-a-node-js-module-without-using-npm)
+As there are some minor changes from NPM, you will need to [Install Manually](http://stackoverflow.com/questions/5786433/how-to-install-a-node-js-module-without-using-npm)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 ## Overview
 This is a pluggable backend for [StatsD](https://github.com/etsy/statsd), which publishes stats to mongodb.
-Forked from [dynmeth/mongo-statsd-backend](https://github.com/dynmeth/mongo-statsd-backend) in order to fix some issues we were having in our environment
 
 ## How it works
 This backend uses Mongo's capped collections to have near file system performance for logging data points from StatsD.
 
 ## Installation
 
-As there are some minor changes from NPN, you will need to [Install Manually](http://stackoverflow.com/questions/5786433/how-to-install-a-node-js-module-without-using-npm)
+`$ npm install mongo-statsd-backend`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 ## Overview
 This is a pluggable backend for [StatsD](https://github.com/etsy/statsd), which publishes stats to mongodb.
+Forked from [dynmeth/mongo-statsd-backend](https://github.com/dynmeth/mongo-statsd-backend) in order to fix some issues we were having in our environment
 
 ## How it works
 This backend uses Mongo's capped collections to have near file system performance for logging data points from StatsD.
 
 ## Installation
 
-`$ npm install mongo-statsd-backend`
+As there are some minor changes from NPN, you will need to [Install Manually](http://stackoverflow.com/questions/5786433/how-to-install-a-node-js-module-without-using-npm)
 
 ## Configuration
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ var connection_queue = async.queue(function(task, callback) {
 	if(dbs[task.name]) {
 		callback(null, dbs[task.name]);
 	} else {
-		new mongo.Db(task.name, new mongo.Server(options.host, options.port)).open(function(err, db) {
+		new mongo.Db(task.name, new mongo.Server(options.host, options.port, {auto_reconnect: true}), {strict: false}).open(function(err, db) {
 			if (err) {
 				callback(err);
 			} else {
@@ -157,7 +157,8 @@ var insert = function(dbName, collection, metric, callback) {
 			return callback(err);
 		};
 
-		db.createCollection(collection, colInfo, function(err, collClient) {      
+		db.collection(collection, colInfo, function(err, collClient) {      
+			if (err) throw err;
 			collClient.insert(metric, function(err, data){
 				if (err) callback(err);
 				if (!err) callback(false, collection);


### PR DESCRIPTION
We had an error with mongo v2.4.5 on debian squeeze with node.js v0.10.10.

When createCollection was called, and the collection did not exist, we were getting a "collection already exists error".  Strange.

The changes:
- Ensure that if there is an error returned on collection creation, that error is thrown
- Creates the database connection with strict = false
- Uses collection instead of createCollection, as this does not cause the error
