### PR TITLE
Insert Bug Fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,7 @@ var aggregate = {
 			data: {
 				time: time,
 				gauge: val
-			},
+			}
 		};
 	},
 	/**
@@ -103,7 +103,7 @@ var aggregate = {
 			data: {
 				time: time,
 				durations: val
-			},
+			}
 		};
 	},
 	/**
@@ -119,7 +119,7 @@ var aggregate = {
 			data: {
 				time: time,
 				count: val
-			},
+			}
 		};
 	},
 	/**
@@ -135,7 +135,7 @@ var aggregate = {
 			data: {
 				time: time,
 				set: val
-			},
+			}
 		};
 	}
 };
@@ -157,11 +157,15 @@ var insert = function(dbName, collection, metric, callback) {
 			return callback(err);
 		};
 
-		db.createCollection(collection, colInfo, function(err, collClient) {      
-			collClient.insert(metric, function(err, data){
-				if (err) callback(err);
-				if (!err) callback(false, collection);
-			});
+		db.createCollection(collection, colInfo, function(err, collClient) {
+            if (err) {
+                callback(err);
+            } else {
+                collClient.insert(metric, function(err, data){
+                    if (err) callback(err);
+                    if (!err) callback(false, collection);
+                });
+            }
 		});
 	});
 };


### PR DESCRIPTION
- Fixed a few JSLint errors
- Fixed a problem where the collection returned by createCollection would be null (when doing an insert).  In my case, the mongo error was "collection already exists". The problem was that the insert method was called on this null object.
